### PR TITLE
fix(member): correct theme color format for Koko

### DIFF
--- a/src/assets/members/members.ts
+++ b/src/assets/members/members.ts
@@ -45,7 +45,7 @@ export const clubMembers = {
         lastInitial: 'h',
         pronouns: 'travis/scott',
         role: 'secretary',
-        theme: '#eacde0ff',
+        theme: '#eacde0',
         bio: 'koko is a high school student and the secretary of bay.works.',
         profilePhoto: () => import('./2/profile.jpeg'),
         content: () => import('./2/content.astro'),


### PR DESCRIPTION
This pull request makes a minor update to the `clubMembers` object in `members.ts`, fixing the value of the `theme` property for one member by removing an extra alpha channel from the hex color code.

- Fixed the `theme` color code for a club member by changing `#eacde0ff` to `#eacde0` in `src/assets/members/members.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the theme color for the member profile “koko,” resulting in a slightly refined tone across related UI elements (e.g., profile sections, badges, or avatars).
  - No functional behavior changes; this is a visual adjustment only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->