### PR TITLE
fix(member): add padding member pages when viewport width is small

### DIFF
--- a/src/pages/member/[id].astro
+++ b/src/pages/member/[id].astro
@@ -58,8 +58,10 @@ const Content = member.content;
             </div>
         </div>
     </div>
-    <div class="flex-grow w-full max-w-4xl text-on-surface-variant flex flex-col gap-4">
-        <Content />
+    <div class="flex-grow w-full flex justify-center px-4 md:px-8">
+        <div class="w-full max-w-4xl text-on-surface-variant flex flex-col gap-4">
+            <Content />
+        </div>
     </div>
     <Footer />
 </Page>


### PR DESCRIPTION
This pull request makes a small layout adjustment to the member details page. The main change centers the member content and improves padding for better responsiveness.

* Centered the member content and added horizontal padding (`px-4 md:px-8`) to the outer container, enhancing the page's appearance and responsiveness. (`src/pages/member/[id].astro`) ([src/pages/member/[id].astroL61-R65](diffhunk://#diff-820c3a4e7153b1c95b142e42bf5e4ef5223c71ab27a8df8ed5e658d06478a055L61-R65))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout presentation on member pages with refined spacing, alignment, and content wrapping for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->